### PR TITLE
Index templates with newer fluentd-elsticsearch plugin.

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:14.04
 
 MAINTAINER Aleksandr Tishin "atishin@cloudlinux.com"
 
-RUN ulimit -n 65536
+# Does not work with newer docker versions.
+# Starting from docker 1.6 there is an --ulimit option for docker run.
+# RUN ulimit -n 65536
 
 RUN apt-get update && \
     apt-get install -y curl && \
@@ -13,7 +15,8 @@ RUN /usr/bin/curl -L http://toolbelt.treasuredata.com/sh/install-ubuntu-trusty-t
 
 RUN sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/init.d/td-agent
 
-RUN /usr/sbin/td-agent-gem install fluent-plugin-elasticsearch fluent-plugin-record-reformer
+RUN /usr/sbin/td-agent-gem install fluent-plugin-elasticsearch --version 1.8.0
+RUN /usr/sbin/td-agent-gem install fluent-plugin-record-reformer --version 0.8.2
 
 WORKDIR /root
 
@@ -22,5 +25,7 @@ EXPOSE 5140/udp
 ADD run.sh /root/
 ADD fluentd.conf.template /root/
 COPY filter_digestadd.rb /etc/td-agent/plugin/
+ADD syslog_index_template.json /root/
+ADD docker_index_template.json /root/
 
 CMD ./run.sh

--- a/fluentd/docker_index_template.json
+++ b/fluentd/docker_index_template.json
@@ -1,0 +1,31 @@
+{
+    "template": "docker-*",
+    "mappings": {
+        "fluentd": {
+            "_all": {"enabled": false},
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "container_id": {
+                    "type": "string", "index": "not_analyzed"
+                },
+                "hostname": {
+                    "type": "string", "index": "not_analyzed"
+                },
+                "hostname_md5": {
+                    "type": "string", "index": "not_analyzed"
+                },
+                "log": {
+                    "type": "string", "index": "no"
+                },
+                "stream": {
+                    "type": "string", "index": "not_analyzed"
+                },
+                "time_nano": {
+                    "type": "long", "coerce": true
+                }
+            }
+        }
+    }
+}

--- a/fluentd/fluentd.conf.template
+++ b/fluentd/fluentd.conf.template
@@ -26,6 +26,8 @@
   logstash_format true
   logstash_prefix docker
   flush_interval 10s
+  template_name docker_index_template
+  template_file /root/docker_index_template.json
 </match>
 
 #
@@ -59,6 +61,8 @@
   logstash_format true
   logstash_prefix syslog
   flush_interval 10s
+  template_name syslog_index_template
+  template_file /root/syslog_index_template.json
 </match>
 
 #

--- a/fluentd/syslog_index_template.json
+++ b/fluentd/syslog_index_template.json
@@ -1,0 +1,29 @@
+{
+    "template": "syslog-*",
+    "mappings": {
+        "fluentd": {
+            "_all": {"enabled": false},
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "host": {
+                    "type": "string", "index": "not_analyzed"
+                },
+                "host_md5": {
+                    "type": "string", "index": "not_analyzed"
+                },
+                "time_nano": {
+                    "type": "long", "coerce": true
+                },
+                "ident":{
+                    "type":"string", "index": "not_analyzed"
+                },
+                "message":{
+                    "type":"string", "index": "no"
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Removed ulimit setting in Dockerfile, because dockerhub won't build such image.